### PR TITLE
fix: draw tree with root node depth

### DIFF
--- a/src/reason/guided_search/tree.py
+++ b/src/reason/guided_search/tree.py
@@ -607,4 +607,4 @@ class SearchTree:
                 draw_node(child, depth + 1)
 
         print(f"\n---------Expanded Tree---------")
-        draw_node(self.root)
+        draw_node(self.root, 0)


### PR DESCRIPTION
The root node has depth 0, drawing the tree would raise an exception without it cause no default value is set.